### PR TITLE
Addition of KeepSessionOpen() IVirtualDirective

### DIFF
--- a/core/src/Assistant.cs
+++ b/core/src/Assistant.cs
@@ -111,6 +111,7 @@ namespace VoiceBridge.Most
             builder.AddDirectiveProcessor((IDirectiveProcessor<TRequest, TResponse>)new SayProcessor());
             builder.AddDirectiveProcessor((IDirectiveProcessor<TRequest, TResponse>)new PlayMediaProcessor());
             builder.AddDirectiveProcessor((IDirectiveProcessor<TRequest, TResponse>)new ImageProcessor());
+            builder.AddDirectiveProcessor((IDirectiveProcessor<TRequest, TResponse>)new SessionProcessor());
         }
 
         private void RegisterIntents<TRequest, TResponse>(EngineBuilder<TRequest, TResponse> engine) 

--- a/core/src/Directives/ImageDirective.cs
+++ b/core/src/Directives/ImageDirective.cs
@@ -7,7 +7,5 @@ namespace VoiceBridge.Most.Directives
     public class ImageDirective : IVirtualDirective
     {
         public IImage Image { get; set; }
-
-        public bool KeepSessionOpen { get; set; }
     }
 }

--- a/core/src/Directives/PlayMediaDirective.cs
+++ b/core/src/Directives/PlayMediaDirective.cs
@@ -8,8 +8,6 @@ namespace VoiceBridge.Most.Directives
             this.Media = media;
         }
 
-        public bool KeepSessionOpen { get; set; }
-        
         public Prompt Prompt { get; }
 
         public Media Media { get; }

--- a/core/src/Directives/Processors/ImageProcessor.cs
+++ b/core/src/Directives/Processors/ImageProcessor.cs
@@ -16,8 +16,6 @@ namespace VoiceBridge.Most.Directives.Processors
     {
         protected override void Process(ImageDirective directive, SkillRequest request, SkillResponse response)
         {
-            response.Content.ShouldEndSession = !directive.KeepSessionOpen;
-
             if (directive.Image is Image)
             {
                 var image = directive.Image as Image;

--- a/core/src/Directives/Processors/PlayMediaProcessor.cs
+++ b/core/src/Directives/Processors/PlayMediaProcessor.cs
@@ -41,7 +41,6 @@ namespace VoiceBridge.Most.Directives.Processors
                 }
             };
 
-            response.Payload.Body.ExpectUserResponse = directive.KeepSessionOpen;
             response.Payload.Body.RichResponse.Items.Add(new SimpleResponseItem
             {
                 Value = new SimpleResponse
@@ -49,6 +48,7 @@ namespace VoiceBridge.Most.Directives.Processors
                     TextToSpeech = "Here is the audio"
                 }
             });
+
             response.Payload.Body.RichResponse.Items.Add(item);
         }
 

--- a/core/src/Directives/Processors/SayProcessor.cs
+++ b/core/src/Directives/Processors/SayProcessor.cs
@@ -11,14 +11,11 @@ namespace VoiceBridge.Most.Directives.Processors
     {
         protected override void Process(SayDirective directive, SkillRequest request, SkillResponse response)
         {
-            response.Content.ShouldEndSession = !directive.KeepSessionOpen;
             response.Content.OutputSpeech = directive.Prompt.ToAlexaSpeech();
         }
 
         protected override void Process(SayDirective directive, AppRequest request, AppResponse response)
         {
-            response.Payload.Body.ExpectUserResponse = directive.KeepSessionOpen;
-
             response.Payload.Body.RichResponse.Items.Add(new SimpleResponseItem
             {
                 Value = new SimpleResponse

--- a/core/src/Directives/Processors/SessionProcessor.cs
+++ b/core/src/Directives/Processors/SessionProcessor.cs
@@ -1,0 +1,22 @@
+using VoiceBridge.Most.Alexa;
+using VoiceBridge.Most.Google;
+using VoiceBridge.Most.VoiceModel.Alexa;
+using VoiceBridge.Most.VoiceModel.GoogleAssistant;
+using VoiceBridge.Most.VoiceModel.GoogleAssistant.ActionSDK;
+using VoiceBridge.Most.VoiceModel.GoogleAssistant.DialogFlow;
+
+namespace VoiceBridge.Most.Directives.Processors
+{
+    public class SessionProcessor : DirectiveProcessorBase<SessionDirective>
+    {
+        protected override void Process(SessionDirective directive, SkillRequest request, SkillResponse response)
+        {
+            response.Content.ShouldEndSession = false;
+        }
+
+        protected override void Process(SessionDirective directive, AppRequest request, AppResponse response)
+        {
+            response.Payload.Body.ExpectUserResponse = true;
+        }
+    }
+}

--- a/core/src/Directives/SayDirective.cs
+++ b/core/src/Directives/SayDirective.cs
@@ -3,7 +3,5 @@ namespace VoiceBridge.Most.Directives
     public class SayDirective : IVirtualDirective
     {
         public Prompt Prompt { get; set; }
-
-        public bool KeepSessionOpen { get; set; }
     }
 }

--- a/core/src/Directives/SessionDirective.cs
+++ b/core/src/Directives/SessionDirective.cs
@@ -1,0 +1,6 @@
+namespace VoiceBridge.Most.Directives
+{
+    public class SessionDirective : IVirtualDirective
+    {
+    }
+}

--- a/core/src/Result.cs
+++ b/core/src/Result.cs
@@ -13,16 +13,12 @@ namespace VoiceBridge.Most
         /// Creates a virtual directive to send a prompt back to the user
         /// </summary>
         /// <param name="prompt">Prompt</param>
-        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
         /// <returns>SayDirective</returns>
-        public static IVirtualDirective Say(
-            Prompt prompt, 
-            bool keepSessionOpen = false)
+        public static IVirtualDirective Say(Prompt prompt)
         {
             return new SayDirective
             {
-                Prompt = prompt,
-                KeepSessionOpen = keepSessionOpen
+                Prompt = prompt
             };
         }
         
@@ -32,14 +28,12 @@ namespace VoiceBridge.Most
         /// </summary>
         /// <param name="intent">IntentConfiguration</param>
         /// <param name="prompt">Prompt</param>
-        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
         /// <returns>SayDirective</returns>
         public static IntentConfiguration Say(
             this IntentConfiguration intent, 
-            Prompt prompt, 
-            bool keepSessionOpen = false)
+            Prompt prompt)
         {
-            return ApplyAction(intent, Say(prompt, keepSessionOpen));
+            return ApplyAction(intent, Say(prompt));
         }
 
 
@@ -88,15 +82,13 @@ namespace VoiceBridge.Most
         /// <param name="intent">IntentConfiguration</param>
         /// <param name="media">Audio Media</param>
         /// <param name="prompt">Prompt to play before the audio</param>
-        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
         /// <returns>Itself</returns>
         public static IntentConfiguration PlayAudio(
             this IntentConfiguration intent,
             Media media, 
-            Prompt prompt, 
-            bool keepSessionOpen = false)
+            Prompt prompt)
         {
-            return ApplyAction(intent, PlayAudio(media, prompt, keepSessionOpen));
+            return ApplyAction(intent, PlayAudio(media, prompt));
         }
         
 
@@ -105,17 +97,12 @@ namespace VoiceBridge.Most
         /// </summary>
         /// <param name="media">Media</param>
         /// <param name="prompt">Prompt to play before the audio</param>
-        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
         /// <returns>PlayAudioDirective</returns>
         public static IVirtualDirective PlayAudio(
             Media media, 
-            Prompt prompt, 
-            bool keepSessionOpen = false)
+            Prompt prompt)
         {
-            return new PlayMediaDirective(media, prompt)
-            {
-                KeepSessionOpen = keepSessionOpen
-            };
+            return new PlayMediaDirective(media, prompt);
         }
 
 
@@ -123,14 +110,12 @@ namespace VoiceBridge.Most
         /// Should intent conditions be satisfied, display an image on the user's device (if supported)
         /// </summary>
         /// <param name="image">Either an Image or ResponsiveImage</param>
-        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
         /// <returns>Itself</returns>
         public static IntentConfiguration ShowImage(
             this IntentConfiguration intent,
-            IImage image,
-            bool keepSessionOpen = false)
+            IImage image)
         {
-            return ApplyAction(intent, ShowImage(image, keepSessionOpen));
+            return ApplyAction(intent, ShowImage(image));
         }
 
 
@@ -138,16 +123,35 @@ namespace VoiceBridge.Most
         /// Create a virtual directive to display an image (if supported)
         /// </summary>
         /// <param name="image">Either an Image or ResponsiveImage</param>
-        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
         /// <returns>ImageDirective</returns>
-        public static IVirtualDirective ShowImage(IImage image,
-            bool keepSessionOpen = false)
+        public static IVirtualDirective ShowImage(IImage image)
         {
             return new ImageDirective
             {
-                Image = image,
-                KeepSessionOpen = keepSessionOpen
+                Image = image
             };
+        }
+
+        
+        /// <summary>
+        /// Controls whether to keep the session open or not
+        /// </summary>
+        /// <returns>SessionDirective</returns>
+        public static IVirtualDirective KeepSessionOpen()
+        {
+            return new SessionDirective();
+        }
+
+
+        /// <summary>
+        /// Controls whether to keep the session open or not
+        /// </summary>
+        /// <param name="keepSessionOpen">False by default. If true, a response will be expected</param>
+        /// <returns>Itself</returns>
+        public static IntentConfiguration KeepSessionOpen(
+            this IntentConfiguration intent)
+        {
+            return ApplyAction(intent, KeepSessionOpen());
         }
 
 

--- a/core/test/Alexa/AlexaResponseFactoryTest.cs
+++ b/core/test/Alexa/AlexaResponseFactoryTest.cs
@@ -16,6 +16,7 @@ namespace VoiceBridge.Most.Test.Alexa
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Directives);
             Assert.NotNull(response.SessionAttributes);
+            Assert.True(response.Content.ShouldEndSession);
         }
 
         [Fact]

--- a/core/test/AssistantTest.cs
+++ b/core/test/AssistantTest.cs
@@ -94,11 +94,12 @@ namespace VoiceBridge.Most.Test
 
         private static void ConfigureWelcomeMessage(Assistant assistant)
         {
+            var text = "Hello! My name is Fakey, and I will give you fake scores for the NHL's pacific division";
+
             assistant
                 .OnLaunch()
-                .Say(
-                    "Hello! My name is Fakey, and I will give you fake scores for the NHL's pacific division"
-                        .AsPrompt(), keepSessionOpen: true);
+                .Say(text.AsPrompt())
+                .KeepSessionOpen();
         }
         
         private static Assistant ConfigureTeamNameIntent(Assistant assistant)

--- a/core/test/Google/ActionResponseBuilder.cs
+++ b/core/test/Google/ActionResponseBuilder.cs
@@ -13,11 +13,13 @@ namespace VoiceBridge.Most.Test.Google
         {
             var context = new ConversationContext();
             var response = new ActionResponseFactory().Create(context);
+
             Assert.Empty(response.Messages);
             Assert.NotNull(response.Payload.Body);
             Assert.Empty(response.Payload.Body.RichResponse.Items);
             Assert.False(response.Payload.Body.ExpectUserResponse);
             Assert.Null(response.Payload.Body.UserStorage);
+            Assert.False(response.Payload.Body.ExpectUserResponse);
         }
 
         [Fact]

--- a/core/test/ResultTest.cs
+++ b/core/test/ResultTest.cs
@@ -10,19 +10,17 @@ namespace VoiceBridge.Most.Test
         public void Say()
         {
             var prompt = new Prompt();
-            var directive = Result.Say(prompt, true) as SayDirective;
+            var directive = Result.Say(prompt) as SayDirective;
             Assert.NotNull(directive);
             Assert.Same(prompt, directive.Prompt);
-            Assert.True(directive.KeepSessionOpen);
         }
 
         [Fact]
         public async Task SayOnIntent()
         {
             var prompt = new Prompt();
-            var directive = await DynamicHandlerHelper.ExecuteHandle<SayDirective>(intent => intent.Say(prompt, true));
+            var directive = await DynamicHandlerHelper.ExecuteHandle<SayDirective>(intent => intent.Say(prompt));
             Assert.Same(prompt, directive.Prompt);
-            Assert.True(directive.KeepSessionOpen);
         }
 
         [Fact]
@@ -56,10 +54,9 @@ namespace VoiceBridge.Most.Test
         {
             var prompt = new Prompt();
             var media = new Media();
-            var directive = (PlayMediaDirective) Result.PlayAudio(media, prompt, true);
+            var directive = (PlayMediaDirective) Result.PlayAudio(media, prompt);
             Assert.Same(prompt, directive.Prompt);
             Assert.Same(media, media);
-            Assert.True(directive.KeepSessionOpen);
         }
 
         [Fact]
@@ -70,6 +67,19 @@ namespace VoiceBridge.Most.Test
             var directive = await DynamicHandlerHelper.ExecuteHandle<PlayMediaDirective>(intent => intent.PlayAudio(media, prompt));
             Assert.Same(media, directive.Media);
             Assert.Same(prompt, directive.Prompt);
+        }
+
+
+        [Fact]
+        public void KeepSessionOpen()
+        {
+            var directive = (SessionDirective)Result.KeepSessionOpen();
+        }
+
+        [Fact]
+        public async Task KeepSessionOpenOnIntent()
+        {
+            var directive = await DynamicHandlerHelper.ExecuteHandle<SessionDirective>(intent => intent.KeepSessionOpen());
         }
     }
 }

--- a/example/Function.cs
+++ b/example/Function.cs
@@ -102,11 +102,13 @@ namespace Sample
 
         private static Assistant ConfigureWelcomeMessage(Assistant assistant)
         {
+            var text = "Hello! My name is Fakey, and I will give you fake scores for the NHL's pacific division";
+
             assistant
                 .OnLaunch()
-                .Say(
-                    "Hello! My name is Fakey, and I will give you fake scores for the NHL's pacific division"
-                        .AsPrompt(), keepSessionOpen: true);
+                .Say(text.AsPrompt())
+                .KeepSessionOpen();
+
             return assistant;      
         }
         

--- a/voicemodel/src/Alexa/ResponseContent.cs
+++ b/voicemodel/src/Alexa/ResponseContent.cs
@@ -16,8 +16,8 @@ namespace VoiceBridge.Most.VoiceModel.Alexa
 
         [JsonProperty("directives", NullValueHandling = NullValueHandling.Ignore)]
         public List<IAlexaDirective> Directives {get; set;} = new List<IAlexaDirective>();
-        
+
         [JsonProperty("shouldEndSession")]
-        public bool ShouldEndSession {get; set;}
+        public bool ShouldEndSession { get; set; } = true;
     }
 }

--- a/voicemodel/src/GoogleAssistant/DialogFlow/ResponseBody.cs
+++ b/voicemodel/src/GoogleAssistant/DialogFlow/ResponseBody.cs
@@ -10,7 +10,7 @@ namespace VoiceBridge.Most.VoiceModel.GoogleAssistant.DialogFlow
         private string userStorage;
 
         [JsonProperty("expectUserResponse")]
-        public bool ExpectUserResponse { get; set; }
+        public bool ExpectUserResponse { get; set; } = false;
 
         [JsonProperty("userStorage")]
         public string UserStorage


### PR DESCRIPTION
By removing the "keepSessionOpen" boolean, the fluent interface is more explicit on usage.  By default, sessions will be closed unless this method is called when building a response.